### PR TITLE
docs: Update README and fix Bastion availability zones

### DIFF
--- a/README.md
+++ b/README.md
@@ -1798,7 +1798,7 @@ graph TD
     LIB --> ARCH[architecture_definitions/<br/>管理グループ階層定義]
     LIB --> ARCHE[archetype_definitions/<br/>ポリシーアーキタイプ]
     
-    META -.依存.-> ALZLIB[platform/alz@2025.09.3<br/>標準ALZライブラリ]
+    META -.依存.-> ALZLIB["platform/alz 2025.09.3<br/>標準ALZライブラリ"]
     
     ARCHE --> ROOT[root_custom.yaml<br/>Rootポリシー]
     ARCHE --> PLATFORM[platform_custom.yaml<br/>Platformポリシー]
@@ -2912,7 +2912,7 @@ module "hub_and_spoke_vnet" {
 
 ```mermaid
 graph TD
-    STD[標準ALZライブラリ<br/>platform/alz@2025.09.3] --> BASE[base_archetype: management]
+    STD["標準ALZライブラリ<br/>platform/alz 2025.09.3"] --> BASE[base_archetype: management]
     CUSTOM[lib/management_custom.yaml] --> OVERRIDE[Override定義]
     
     BASE --> MERGE[マージ処理]

--- a/platform-landing-zone.auto.tfvars
+++ b/platform-landing-zone.auto.tfvars
@@ -428,6 +428,7 @@ hub_virtual_networks = {
     bastion = {
       subnet_address_prefix = "$${primary_bastion_subnet_address_prefix}"
       name                  = "$${primary_bastion_host_name}"
+      zones                 = []
       bastion_public_ip = {
         name = "$${primary_bastion_host_public_ip_name}"
       }
@@ -518,6 +519,7 @@ hub_virtual_networks = {
     bastion = {
       subnet_address_prefix = "$${secondary_bastion_subnet_address_prefix}"
       name                  = "$${secondary_bastion_host_name}"
+      zones                 = []
       bastion_public_ip = {
         name = "$${secondary_bastion_host_public_ip_name}"
       }


### PR DESCRIPTION
## 変更内容

### 1. READMEの日本語詳細解説版に更新
- リポジトリ構造の完全解説
- 10+のMermaid図で視覚化
- 再構築ガイド追加
- Mermaidダイアグラムのパースエラー修正

### 2. Bastion可用性ゾーンの無効化
- Japan EastとJapan Westリージョンでの可用性ゾーン無効化
- CDエラー解消: `BastionRegionAzNotSupported`

## テスト
- [ ] Mermaidダイアグラムが正しく表示される
- [ ] CDパイプラインがエラーなく実行される