### PR TITLE
fix: Add zones=[] to Bastion Public IP configurations

### DIFF
--- a/platform-landing-zone.auto.tfvars
+++ b/platform-landing-zone.auto.tfvars
@@ -430,7 +430,8 @@ hub_virtual_networks = {
       name                  = "$${primary_bastion_host_name}"
       zones                 = []
       bastion_public_ip = {
-        name = "$${primary_bastion_host_public_ip_name}"
+        name  = "$${primary_bastion_host_public_ip_name}"
+        zones = []
       }
     }
   }
@@ -521,7 +522,8 @@ hub_virtual_networks = {
       name                  = "$${secondary_bastion_host_name}"
       zones                 = []
       bastion_public_ip = {
-        name = "$${secondary_bastion_host_public_ip_name}"
+        name  = "$${secondary_bastion_host_public_ip_name}"
+        zones = []
       }
     }
   }


### PR DESCRIPTION
## 問題
前回のPRでBastion Hostの`zones = []`を設定しましたが、Public IPのzones設定が残っていたため、moduleの検証でエラーが発生しました。

## エラー内容
```
Error: Resource precondition failed
The number of zones in the public IP address must match the number of zones in the Azure Bastion Host.
```

## 修正内容
- Primary Bastion Public IPに`zones = []`を追加
- Secondary Bastion Public IPに`zones = []`を追加
- Bastion HostとPublic IPのzone設定を一致させる

## 検証
- [ ] Terraform Planが成功する
- [ ] CDパイプラインが完了する