### PR TITLE
fix: Use official GitHub Pages deployment action

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -13,11 +13,21 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
+
+# 同時実行の制限（デプロイが重複しないように）
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v4
       
@@ -51,9 +61,11 @@ jobs:
           cd docs-site
           mkdocs build
       
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs-site/site
-          commit_message: 'docs: update documentation site'
+          path: ./docs-site/site
+      
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## 問題

GitHub Pagesが404を返し続ける原因は、`build_type: workflow` 設定と peaceiris/actions-gh-pages アクションの組み合わせにありました。

peaceiris アクションは gh-pages ブランチにプッシュするだけで、GitHub Actions の公式デプロイメントAPIを使用していないため、GitHub Pages が新しいデプロイを認識できませんでした。

## 解決策

GitHub公式のデプロイメントアクションに変更：
- `actions/upload-pages-artifact@v3`: ビルド済みサイトをアーティファクトとしてアップロード
- `actions/deploy-pages@v4`: GitHub Pages に公式デプロイ

## 変更内容

- ✅ peaceiris/actions-gh-pages を削除
- ✅ actions/deploy-pages に変更
- ✅ pages write と id-token 権限を追加
- ✅ github-pages environment 設定を追加
- ✅ 同時実行制限を追加

これで404エラーが解決し、サイトが正常に公開されます。