### PR TITLE
docs: 02_プロジェクト構造.md装飾完了Part2（完結）

### DIFF
--- a/docs-site/docs/02_プロジェクト構造.md
+++ b/docs-site/docs/02_プロジェクト構造.md
@@ -503,7 +503,7 @@ for_each = local.resource_groups
 ```
 
 `local.resource_groups`は例えばこんな感じ：
-```hcl
+```hcl title="for_eachでループ"
 {
   "primary_connectivity" = {
     name     = "rg-hub-japaneast"
@@ -527,7 +527,7 @@ for_each = local.resource_groups
 **役割**: 管理グループとポリシーを作る  
 **重要度**: ★★★★★
 
-```hcl
+```hcl title="main.management.tf"
 module "management_groups" {
   count  = var.management_group_settings.enabled ? 1 : 0
   source = "./modules/management_groups"
@@ -550,7 +550,7 @@ module "management_groups" {
 
 名前が長すぎるよね()
 
-```hcl
+```hcl title="Hub-Spokeネットワークの作成"
 module "hub_and_spoke_vnet" {
   count   = var.hub_and_spoke_vnet_settings.enabled ? 1 : 0
   source  = "Azure/avm-ptn-alz-connectivity-hub-and-spoke-vnet/azurerm"
@@ -571,7 +571,7 @@ Firewall, Bastion, VPN Gateway, VNet全部ここで作られます。
 
 Hub-Spokeの代わりにVirtual WANを使う場合。
 
-```hcl
+```hcl title="Virtual WANの作成"
 module "virtual_wan" {
   count   = var.virtual_wan_settings.enabled ? 1 : 0
   source  = "Azure/avm-ptn-alz-connectivity-virtual-wan/azurerm"
@@ -592,7 +592,7 @@ module "virtual_wan" {
 **役割**: 作ったリソースの情報を出力  
 **重要度**: ★★☆☆☆
 
-```hcl
+```hcl title="outputs.tf"
 output "resource_groups" {
   value = module.resource_groups
   description = "Created resource groups"
@@ -613,7 +613,7 @@ output "hub_virtual_network_id" {
 - ドキュメント生成用
 
 **try関数**
-```hcl
+```hcl title="エラー回避"
 try(
   module.hub_and_spoke_vnet[0].virtual_networks.primary.id,
   null
@@ -630,7 +630,7 @@ try(
 
 **役割**: 設定ファイルのテンプレート処理
 
-```
+```text title="モジュール構造"
 modules/config-templating/
 ├── data.tf          ← データソース定義
 ├── locals.config.tf ← テンプレート置換ロジック
@@ -647,7 +647,7 @@ modules/config-templating/
 
 **役割**: 管理グループとポリシーを作る
 
-```
+```text title="モジュール構造"
 modules/management_groups/
 ├── locals.tf     ← ローカル変数
 ├── main.tf       ← メイン処理
@@ -662,7 +662,7 @@ modules/management_groups/
 
 **役割**: Log AnalyticsとAutomation Accountを作る
 
-```
+```text title="モジュール構造"
 modules/management_resources/
 ├── main.tf       ← メイン処理
 ├── outputs.tf    ← 出力
@@ -680,7 +680,7 @@ modules/management_resources/
 
 **役割**: ポリシー定義をYAMLで管理
 
-```
+```text title="libフォルダ構造"
 lib/
 ├── alz_library_metadata.json        ← メタデータ
 ├── archetype_definitions/           ← 管理グループの種類
@@ -706,7 +706,7 @@ lib/
 各アーキタイプに適用するポリシーがYAMLで定義されています。
 
 例: `corp_custom.alz_archetype_override.yaml`
-```yaml
+```yaml title="ポリシー定義の例"
 archetypes:
   corp:
     policy_assignments:
@@ -724,7 +724,7 @@ archetypes:
 
 **役割**: GitHub Actionsの設定
 
-```yaml
+```yaml title="cd.yaml"
 name: 02 Azure Landing Zones Continuous Delivery
 
 on:
@@ -773,7 +773,7 @@ jobs:
 
 ### データの流れ（再掲）
 
-```
+```text title="全体のフロー"
 .tfvars（設定）
   ↓
 variables.tf（変数定義）
@@ -845,7 +845,7 @@ countは数値でリソースを作ります（`count = 3`なら3個）。イン
 for_eachはマップやセットでリソースを作ります。各要素に名前があり、`each.key`や`each.value`でアクセスできます。
 
 例：
-```hcl
+```hcl title="count vs for_each"
 # count: リソース名が resource[0], resource[1]...
 count = 2
 


### PR DESCRIPTION
## 変更内容
- mainファイル群（management, connectivity）にコードタイトル追加
- outputs.tf, try関数にコードタイトル追加
- モジュール構造（config-templating, management_groups, management_resources）にタイトル追加
- lib/ポリシー定義、GitHub Actionsにタイトル追加
- まとめ、練習問題の例にタイトル追加

## 確認
- 文章内容変更なし: ✅
- ビルド成功: ✅
- **Chapter 02完全装飾完了**: ✅