### PR TITLE
docs: 04_変数定義.md装飾完了

### DIFF
--- a/docs-site/docs/04_変数定義.md
+++ b/docs-site/docs/04_変数定義.md
@@ -18,7 +18,7 @@ Chapter 3で見た`platform-landing-zone.auto.tfvars`（設定ファイル）の
 **3つの役割がある**：
 
 ### 1. 型の定義
-```hcl
+```hcl title="型の定義例"
 variable "starter_locations" {
   type = list(string)  # ←文字列のリスト
 }
@@ -27,7 +27,7 @@ variable "starter_locations" {
 「これは文字列のリストです」と宣言しています。
 
 ### 2. バリデーション
-```hcl
+```hcl title="値のチェック"
 validation {
   condition     = length(var.starter_locations) > 0
   error_message = "最低1つのリージョンが必要です"
@@ -37,7 +37,7 @@ validation {
 間違った値が入ってたらエラーを出す。
 
 ### 3. デフォルト値
-```hcl
+```hcl title="初期値の設定"
 variable "enable_telemetry" {
   type    = bool
   default = true  # ←指定しなかったらtrue
@@ -52,7 +52,7 @@ variable "enable_telemetry" {
 
 ### starter_locations
 
-```hcl
+```hcl title="リージョン設定変数"
 variable "starter_locations" {
   type        = list(string)
   description = "The default for Azure resources. (e.g 'uksouth')"
@@ -79,20 +79,20 @@ type = list(string)
 **意味**：文字列のリスト
 
 **OK例**：
-```hcl
+```hcl title="正しい記述例"
 starter_locations = ["japaneast", "japanwest"]  # ✅
 starter_locations = ["eastus"]                   # ✅
 ```
 
 **NG例**：
-```hcl
+```hcl title="間違った記述例"
 starter_locations = "japaneast"     # ❌ リストじゃない
 starter_locations = [123, 456]      # ❌ 文字列じゃない
 starter_locations = []              # ❌ 空はダメ（次のバリデーションでエラー）
 ```
 
 #### validation 1: 最低1個必要
-```hcl
+```hcl title="空リスト禁止のチェック"
 validation {
   condition     = length(var.starter_locations) > 0
   error_message = "You must provide at least one starter location region."
@@ -127,7 +127,7 @@ validation {
 - Hub VNet 3個なのにリージョン2個だと足りないからエラー
 
 **例**：
-```hcl
+```hcl title="正しい設定例"
 # OK
 starter_locations = ["japaneast", "japanwest"]
 hub_virtual_networks = {
@@ -145,7 +145,7 @@ hub_virtual_networks = {
 
 ### starter_locations_short
 
-```hcl
+```hcl title="リージョン短縮コードのオーバーライド"
 variable "starter_locations_short" {
   type        = map(string)
   default     = {}
@@ -165,7 +165,7 @@ DESCRIPTION
 - `japanwest` → `jpw`（自動生成）
 
 **手動で変えたい場合**：
-```hcl
+```hcl title="短縮コードのカスタマイズ"
 starter_locations_short = {
   starter_location_01_short = "je"   # jpeじゃなくてjeにしたい
   starter_location_02_short = "jw"   # jpwじゃなくてjwにしたい
@@ -180,7 +180,7 @@ starter_locations_short = {
 
 ### subscription_ids（新しい方式）
 
-```hcl
+```hcl title="サブスクリプションID変数（推奨）"
 variable "subscription_ids" {
   description = "The list of subscription IDs to deploy the Platform Landing Zones into"
   type        = map(string)
@@ -203,7 +203,7 @@ variable "subscription_ids" {
 キーと値のペア。
 
 **使い方**：
-```hcl
+```hcl title="サブスクリプションIDの設定例"
 subscription_ids = {
   management   = "12345678-1234-1234-1234-123456789012"
   connectivity = "87654321-4321-4321-4321-210987654321"
@@ -213,7 +213,7 @@ subscription_ids = {
 ```
 
 #### validation 1: GUID形式チェック
-```hcl
+```hcl title="サブスクリプションIDの形式チェック"
 validation {
   condition     = length(var.subscription_ids) == 0 || alltrue([for id in values(var.subscription_ids) : can(regex("^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$", id))])
   error_message = "All subscription IDs must be valid GUIDs"
@@ -236,7 +236,7 @@ subscription_ids = {
 ```
 
 #### validation 2: キー名チェック
-```hcl
+```hcl title="許可されたキー名のチェック"
 validation {
   condition     = length(var.subscription_ids) == 0 || alltrue([for id in keys(var.subscription_ids) : contains(["management", "connectivity", "identity", "security"], id)])
   error_message = "The keys of the subscription_ids map must be one of 'management', 'connectivity', 'identity' or 'security'"
@@ -257,7 +257,7 @@ subscription_ids = {
 
 ### subscription_id_connectivity（古い方式）
 
-```hcl
+```hcl title="非推奨：古いサブスクリプションID設定"
 variable "subscription_id_connectivity" {
   description = "DEPRECATED (use subscription_ids instead): The identifier of the Connectivity Subscription"
   type        = string
@@ -297,7 +297,7 @@ subscription_ids = {
 
 ### root_parent_management_group_id
 
-```hcl
+```hcl title="管理グループの親設定"
 variable "root_parent_management_group_id" {
   type        = string
   default     = ""
@@ -315,7 +315,7 @@ Tenant Root Group（テナントルート）
 ```
 
 **既存の管理グループの下に作りたい場合**：
-```hcl
+```hcl title="カスタム親管理グループの指定"
 root_parent_management_group_id = "/providers/Microsoft.Management/managementGroups/my-company"
 
 # 結果
@@ -331,7 +331,7 @@ my-company
 
 ### enable_telemetry
 
-```hcl
+```hcl title="テレメトリー有効/無効設定"
 variable "enable_telemetry" {
   type        = bool
   default     = true
@@ -346,7 +346,7 @@ Microsoftに使用状況データを送るかどうか。
 **false**：送らない
 
 無効にしたい場合：
-```hcl
+```hcl title="テレメトリーを無効化"
 enable_telemetry = false
 ```
 
@@ -354,7 +354,7 @@ enable_telemetry = false
 
 ### custom_replacements
 
-```hcl
+```hcl title="カスタム置換変数"
 variable "custom_replacements" {
   type = object({
     names                      = optional(map(string), {})
@@ -376,7 +376,7 @@ variable "custom_replacements" {
 **object型とは？**
 JavaScriptのオブジェクトみたいなやつ。
 
-```hcl
+```hcl title="custom_replacementsの使用例"
 custom_replacements = {
   names = {
     firewall_name = "fw-custom-name"
@@ -409,7 +409,7 @@ Chapter 3で見た設定が、ここで定義されてるわけ。
 
 ### tags
 
-```hcl
+```hcl title="タグ変数"
 variable "tags" {
   type        = map(string)
   default     = null
@@ -421,7 +421,7 @@ variable "tags" {
 **デフォルト**：`null`（何も指定しなければタグなし）
 
 **使い方**：
-```hcl
+```hcl title="タグの設定例"
 tags = {
   environment = "production"
   cost_center = "IT"
@@ -438,7 +438,7 @@ Terraformでよく使う型をまとめとくね。
 ### プリミティブ型（基本型）
 
 #### string（文字列）
-```hcl
+```hcl title="文字列型の定義"
 variable "name" {
   type = string
 }
@@ -448,7 +448,7 @@ name = "my-resource"
 ```
 
 #### number（数値）
-```hcl
+```hcl title="数値型の定義"
 variable "count" {
   type = number
 }
@@ -458,7 +458,7 @@ count = 3
 ```
 
 #### bool（真偽値）
-```hcl
+```hcl title="真偽値型の定義"
 variable "enabled" {
   type = bool
 }
@@ -470,7 +470,7 @@ enabled = true
 ### コレクション型（複数の値）
 
 #### list（リスト）
-```hcl
+```hcl title="リスト型の定義"
 variable "locations" {
   type = list(string)
 }
@@ -480,7 +480,7 @@ locations = ["japaneast", "japanwest"]
 ```
 
 #### map（マップ）
-```hcl
+```hcl title="マップ型の定義"
 variable "tags" {
   type = map(string)
 }
@@ -493,7 +493,7 @@ tags = {
 ```
 
 #### set（セット）
-```hcl
+```hcl title="セット型の定義"
 variable "unique_items" {
   type = set(string)
 }
@@ -505,7 +505,7 @@ unique_items = ["a", "b", "c"]  # 重複は自動削除される
 ### 構造型（複雑な構造）
 
 #### object（オブジェクト）
-```hcl
+```hcl title="オブジェクト型の定義"
 variable "vm_config" {
   type = object({
     name = string
@@ -523,7 +523,7 @@ vm_config = {
 ```
 
 #### optional（省略可能）
-```hcl
+```hcl title="省略可能なフィールドの定義"
 variable "config" {
   type = object({
     name = string
@@ -550,7 +550,7 @@ config = {
 
 ### 基本パターン
 
-```hcl
+```hcl title="バリデーションの基本構文"
 variable "example" {
   type = string
   
@@ -566,7 +566,7 @@ variable "example" {
 ### よく使うパターン
 
 #### 長さチェック
-```hcl
+```hcl title="リストの長さチェック"
 validation {
   condition     = length(var.my_list) > 0
   error_message = "リストは最低1個必要"
@@ -574,7 +574,7 @@ validation {
 ```
 
 #### 正規表現チェック
-```hcl
+```hcl title="文字列パターンのチェック"
 validation {
   condition     = can(regex("^[a-z0-9-]+$", var.name))
   error_message = "名前は小文字、数字、ハイフンのみ"
@@ -582,7 +582,7 @@ validation {
 ```
 
 #### 値の範囲チェック
-```hcl
+```hcl title="数値範囲のチェック"
 validation {
   condition     = var.count >= 1 && var.count <= 10
   error_message = "countは1〜10の間"
@@ -590,7 +590,7 @@ validation {
 ```
 
 #### 選択肢チェック
-```hcl
+```hcl title="許可された値のチェック"
 validation {
   condition     = contains(["dev", "stg", "prod"], var.environment)
   error_message = "environmentはdev、stg、prodのどれか"
@@ -598,7 +598,7 @@ validation {
 ```
 
 #### リスト全要素チェック
-```hcl
+```hcl title="全要素の条件チェック"
 validation {
   condition     = alltrue([for item in var.items : length(item) > 3])
   error_message = "全ての要素は4文字以上"
@@ -612,7 +612,7 @@ validation {
 例えば、「Firewallの名前をカスタマイズしたい」って時。
 
 ### 1. variables.tfに追加
-```hcl
+```hcl title="カスタムFirewall名変数の定義"
 variable "custom_firewall_name" {
   type        = string
   default     = null
@@ -626,12 +626,12 @@ variable "custom_firewall_name" {
 ```
 
 ### 2. platform-landing-zone.auto.tfvarsで使う
-```hcl
+```hcl title="カスタムFirewall名の設定"
 custom_firewall_name = "fw-my-custom-firewall"
 ```
 
 ### 3. main.tfで参照
-```hcl
+```hcl title="Firewallリソースで変数を使用"
 resource "azurerm_firewall" "example" {
   name = var.custom_firewall_name != null ? var.custom_firewall_name : "fw-default"
   ...


### PR DESCRIPTION
Chapter 04にコードタイトルを追加

- 型定義、バリデーション、デフォルト値の例にタイトル追加
- starter_locations変数とそのバリデーションにタイトル追加
- subscription_ids変数（新旧両方）にタイトル追加
- root_parent、enable_telemetry、custom_replacements、tagsにタイトル追加
- 全ての基本型（string、number、bool）にタイトル追加
- 全てのコレクション型（list、map、set）にタイトル追加
- object型、optional型にタイトル追加
- 全てのバリデーションパターン例にタイトル追加
- 実践例（カスタムFirewall名追加）にタイトル追加

**Chapter 04装飾完了！文章内容は一切変更していません**