### PR TITLE
docs: 05_ローカル変数.md装飾完了

### DIFF
--- a/docs-site/docs/05_ローカル変数.md
+++ b/docs-site/docs/05_ローカル変数.md
@@ -18,7 +18,7 @@
 
 ### 定義方法
 
-```hcl
+```hcl title="ローカル変数の定義"
 locals {
   project_name = "alz"
   full_name    = "${local.project_name}-${var.environment}"
@@ -26,7 +26,7 @@ locals {
 ```
 
 **使い方**：
-```hcl
+```hcl title="ローカル変数の参照"
 resource "azurerm_resource_group" "example" {
   name     = local.full_name  # ←local.で参照
   location = var.location     # ←変数はvar.で参照
@@ -52,7 +52,7 @@ resource "azurerm_resource_group" "example" {
 
 **具体例で理解する**:
 
-```hcl
+```hcl title="variablesとlocalsの使い分け"
 # variables.tf（ユーザーが決める）
 variable "environment" {
   type = string
@@ -115,7 +115,7 @@ locals {
 
 **🎯 具体例でもう一度**
 
-```hcl
+```hcl title="実際の使用例"
 # ① ユーザーからの入力
 variable "project" { default = "webapp" }
 variable "env" { default = "prod" }
@@ -158,7 +158,7 @@ resource "azurerm_resource_group" "main" {
 
 ## Part 1: 定数定義
 
-```hcl
+```hcl title="接続タイプの定数定義"
 locals {
   const = {
     connectivity = {
@@ -174,14 +174,14 @@ locals {
 定数を定義しています。マジックストリング（文字列直書き）を避けるためです。
 
 **悪い例**：
-```hcl
+```hcl title="マジックストリング（非推奨）"
 if (var.connectivity_type == "hub_and_spoke_vnet") {  # ←タイポしやすい
   ...
 }
 ```
 
 **良い例**：
-```hcl
+```hcl title="定数を使った安全な記述"
 if (var.connectivity_type == local.const.connectivity.hub_and_spoke_vnet) {
   # ←補完が効く、タイポしたらエラーになる
   ...
@@ -200,7 +200,7 @@ if (var.connectivity_type == local.const.connectivity.hub_and_spoke_vnet) {
 
 ## Part 2: 接続タイプの判定
 
-```hcl
+```hcl title="接続タイプによるフラグ設定"
 locals {
   connectivity_enabled                    = var.connectivity_type != local.const.connectivity.none
   connectivity_virtual_wan_enabled        = var.connectivity_type == local.const.connectivity.virtual_wan
@@ -213,7 +213,7 @@ locals {
 
 ### connectivity_enabled
 
-```hcl
+```hcl title="ネットワーク有効化フラグ"
 connectivity_enabled = var.connectivity_type != local.const.connectivity.none
 ```
 
@@ -301,7 +301,7 @@ module "virtual_wan" {
 
 ## Part 3: リソースグループの依存関係
 
-```hcl
+```hcl title="リソース作成順序の制御"
 locals {
   resource_groups = {
     resource_groups = module.resource_groups
@@ -416,7 +416,7 @@ merge(
 
 ## Part 4: ポリシーの依存関係
 
-```hcl
+```hcl title="ポリシー割り当ての依存関係定義"
 locals {
   management_group_dependencies = {
     policy_assignments = [
@@ -472,7 +472,7 @@ policy_assignments = [
 
 ### management_group_settings
 
-```hcl
+```hcl title="管理グループ設定のマージ"
 locals {
   management_group_settings = merge(
     module.config.outputs.management_group_settings,
@@ -509,7 +509,7 @@ management_group_settings = {
 
 ### management_resource_settings
 
-```hcl
+```hcl title="管理リソース設定のマージ"
 locals {
   management_resource_settings = merge(
     module.config.outputs.management_resource_settings,
@@ -567,7 +567,7 @@ management_resource_settings.tags = { environment = "prod" }
 
 ### パターン1: 定数定義
 
-```hcl
+```hcl title="enumパターン"
 locals {
   const = {
     status = {
@@ -585,7 +585,7 @@ status = local.const.status.active
 
 ### パターン2: 条件分岐
 
-```hcl
+```hcl title="環境別の分岐"
 locals {
   is_production = var.environment == "prod"
   instance_count = local.is_production ? 3 : 1
@@ -596,7 +596,7 @@ locals {
 
 ### パターン3: データ加工
 
-```hcl
+```hcl title="リージョン名の短縮"
 locals {
   location_short = {
     "japaneast" = "jpe"
@@ -611,7 +611,7 @@ locals {
 
 ### パターン4: 依存関係の明示
 
-```hcl
+```hcl title="リソース作成順序の制御"
 locals {
   config_with_deps = merge(
     var.config,
@@ -624,7 +624,7 @@ locals {
 
 ### パターン5: デフォルト値のフォールバック
 
-```hcl
+```hcl title="省略時のデフォルト値"
 locals {
   tags = coalesce(var.custom_tags, var.default_tags)
 }
@@ -638,7 +638,7 @@ locals {
 
 ### 例1: 環境別の設定
 
-```hcl
+```hcl title="環境による設定切り替え"
 # variables.tf
 variable "environment" {
   type = string
@@ -670,7 +670,7 @@ resource "azurerm_virtual_machine" "example" {
 
 ### 例2: 命名規則の統一
 
-```hcl
+```hcl title="リソース名の自動生成"
 # variables.tf
 variable "project" { type = string }
 variable "environment" { type = string }
@@ -705,7 +705,7 @@ resource "azurerm_virtual_network" "example" {
 
 ### 例3: 条件付きリソース作成
 
-```hcl
+```hcl title="機能の有効/無効制御"
 # variables.tf
 variable "enable_monitoring" { type = bool }
 variable "enable_backup" { type = bool }
@@ -742,7 +742,7 @@ resource "azurerm_monitor_diagnostic_setting" "advanced" {
 
 **output使おう**
 
-```hcl
+```hcl title="デバッグ用output定義"
 # outputs.tf
 output "debug_locals" {
   value = {
@@ -798,7 +798,7 @@ Outputs:
 ### 問題1
 以下のコードで、`local.resource_group_name`の値は何になりますか？
 
-```hcl
+```hcl title="練習問題1"
 variable "environment" {
   default = "prod"
 }
@@ -819,7 +819,7 @@ locals {
 ### 問題3
 以下のコードは何をしていますか？
 
-```hcl
+```hcl title="練習問題3"
 locals {
   is_production = var.environment == "prod" ? true : false
 }


### PR DESCRIPTION
Chapter 05にコードタイトルを追加

- locals定義方法、使用例にタイトル追加
- variablesとの違いの具体例にタイトル追加
- 定数定義（enum パターン）にタイトル追加
- 接続タイプ判定フラグにタイトル追加
- リソースグループ依存関係、ポリシー依存関係にタイトル追加
- management_group_settings、management_resource_settingsにタイトル追加
- 全5パターン（定数、条件分岐、データ加工、依存関係、デフォルト値）にタイトル追加
- 実践例3つ（環境別設定、命名規則統一、条件付きリソース作成）にタイトル追加
- デバッグ技、練習問題にタイトル追加

**Chapter 05装飾完了！文章内容は一切変更していません**