### PR TITLE
docs: 06_設定テンプレート.md装飾完了

### DIFF
--- a/docs-site/docs/06_設定テンプレート.md
+++ b/docs-site/docs/06_設定テンプレート.md
@@ -17,7 +17,7 @@
 
 ## モジュールの構成
 
-```
+```title="modules/config-templating/のファイル構成"
 modules/config-templating/
   ├── data.tf           # 外部データ取得
   ├── locals.config.tf  # テンプレート処理のロジック
@@ -38,7 +38,7 @@ modules/config-templating/
 
 ### starter_locations
 
-```hcl
+```hcl title="リージョンリストの入力変数"
 variable "starter_locations" {
   type        = list(string)
   description = "The default for Azure resources. (e.g 'uksouth')"
@@ -46,13 +46,13 @@ variable "starter_locations" {
 ```
 
 **例**：
-```hcl
+```hcl title="リージョン設定例"
 starter_locations = ["japaneast", "japanwest"]
 ```
 
 ### subscription_id_xxx
 
-```hcl
+```hcl title="サブスクリプションID入力変数"
 variable "subscription_id_connectivity" {
   type        = string
   description = "value of the subscription id for the Connectivity subscription"
@@ -63,7 +63,7 @@ variable "subscription_id_connectivity" {
 
 ### custom_replacements
 
-```hcl
+```hcl title="カスタム置換入力変数"
 variable "custom_replacements" {
   type = object({
     names                      = optional(map(string), {})
@@ -77,7 +77,7 @@ Chapter 3で見た`custom_replacements`をそのまま受け取るんだ。
 
 ### inputs
 
-```hcl
+```hcl title="入力データ変数"
 variable "inputs" {
   type        = any
   description = "A map of input variables"
@@ -94,7 +94,7 @@ variable "inputs" {
 
 ### regions モジュール
 
-```hcl
+```hcl title="Azureリージョン情報の取得"
 module "regions" {
   source           = "Azure/avm-utl-regions/azurerm"
   version          = "0.9.2"
@@ -123,7 +123,7 @@ module.regions.regions_by_name["japaneast"].short_name  # ←"jpe"
 
 ### azurerm_client_config
 
-```hcl
+```hcl title="Azure接続情報の取得"
 data "azurerm_client_config" "current" {}
 ```
 
@@ -143,7 +143,7 @@ data "azurerm_client_config" "current" {}
 
 #### starter_locations
 
-```hcl
+```hcl title="リージョンリストのマップ化"
 locals {
   starter_locations = {
     for i, location in var.starter_locations :
@@ -180,7 +180,7 @@ format("%02d", 15)  # ←"15"
 
 #### starter_locations_short
 
-```hcl
+```hcl title="リージョン短縮名の生成"
 locals {
   starter_locations_short = {
     for i, location in var.starter_locations :
@@ -262,7 +262,7 @@ local.starter_locations_short = {
 
 #### built_in_replacements
 
-```hcl
+```hcl title="組み込み置換ルールの統合"
 locals {
   built_in_replacements = merge(
     local.starter_locations,
@@ -306,7 +306,7 @@ local.built_in_replacements = {
 
 #### custom_names
 
-```hcl
+```hcl title="カスタム名のテンプレート処理"
 locals {
   custom_names_json           = replace(replace(tostring(jsonencode(var.custom_replacements.names)), "\"true\"", "{{string_true}}"), "\"false\"", "{{string_false}}")
   custom_names_json_templated = templatestring(local.custom_names_json, local.built_in_replacements)
@@ -434,7 +434,7 @@ local.custom_names = {
 
 #### custom_name_replacements
 
-```hcl
+```hcl title="カスタム名と組み込みのマージ"
 locals {
   custom_name_replacements = merge(local.built_in_replacements, local.custom_names)
 }
@@ -448,7 +448,7 @@ locals {
 
 #### custom_resource_group_identifiers
 
-```hcl
+```hcl title="リソースグループIDのテンプレート処理"
 locals {
   custom_resource_group_identifiers_json           = replace(replace(tostring(jsonencode(var.custom_replacements.resource_group_identifiers)), "\"true\"", "{{string_true}}"), "\"false\"", "{{string_false}}")
   custom_resource_group_identifiers_json_templated = templatestring(local.custom_resource_group_identifiers_json, local.custom_name_replacements)
@@ -485,7 +485,7 @@ custom_replacements = {
 
 #### custom_resource_identifiers
 
-```hcl
+```hcl title="リソースIDのテンプレート処理"
 locals {
   custom_resource_identifiers_json           = replace(replace(tostring(jsonencode(var.custom_replacements.resource_identifiers)), "\"true\"", "{{string_true}}"), "\"false\"", "{{string_false}}")
   custom_resource_identifiers_json_templated = templatestring(local.custom_resource_identifiers_json, local.custom_resource_group_replacements)
@@ -501,7 +501,7 @@ locals {
 
 #### final_replacements
 
-```hcl
+```hcl title="全置換ルールの統合"
 locals {
   final_replacements = merge(local.custom_resource_group_replacements, local.custom_resource_identifiers)
 }
@@ -533,7 +533,7 @@ local.final_replacements = {
 
 ### ステップ4: 最終出力の生成
 
-```hcl
+```hcl title="全設定へのテンプレート適用"
 locals {
   outputs_json           = { for key, value in var.inputs : key => replace(replace(tostring(jsonencode(value)), "\"true\"", "{{string_true}}"), "\"false\"", "{{string_false}}") }
   outputs_json_templated = { for key, value in local.outputs_json : key => templatestring(value, local.final_replacements) }
@@ -630,7 +630,7 @@ local.outputs → module.config.outputs
 
 ### 例1: 単純な置換
 
-```hcl
+```hcl title="基本的なテンプレート置換"
 # tfvars
 starter_locations = ["japaneast"]
 
@@ -646,7 +646,7 @@ custom_replacements = {
 
 ### 例2: 複数段階の置換
 
-```hcl
+```hcl title="依存関係を持つ置換"
 # tfvars
 starter_locations = ["japaneast"]
 
@@ -672,7 +672,7 @@ custom_replacements = {
 
 ### 例3: 条件分岐（ブール値）
 
-```hcl
+```hcl title="ブール値の保持"
 # tfvars
 custom_replacements = {
   names = {
@@ -692,7 +692,7 @@ custom_replacements = {
 
 ### outputで中間結果を見る
 
-```hcl
+```hcl title="デバッグ用output定義"
 # modules/config-templating/outputs.tf
 output "debug_replacements" {
   value = {
@@ -717,7 +717,7 @@ Outputs:
 
 ### 特定の値だけ確認
 
-```hcl
+```hcl title="個別値のデバッグ"
 output "debug_vnet_name" {
   value = local.outputs.hub_virtual_networks.primary.name
 }


### PR DESCRIPTION
## 変更内容

- Chapter 06（06_設定テンプレート.md）に22個のコードタイトルを追加
- config-templatingモジュールの説明を装飾
- テンプレート処理、JSON変換トリック、実践例にコードタイトルを付与

## 装飾内容

- モジュール構造
- 入力変数（starter_locations, subscription_ids, custom_replacements, inputs）
- データソース（regions module, azurerm_client_config）
- テンプレート処理（4段階）
- カスタム名/リソース識別子処理
- 最終出力生成
- 実践例3つ
- デバッグ技術

## 確認事項

- [x] 文章は一言一句変更していない（マークアップのみ追加）
- [x] ビルド成功を確認
- [x] コードタイトルのみ追加（コード内容は変更なし）