### PR TITLE
docs: 08_管理グループとポリシー.md装飾完了

### DIFF
--- a/docs-site/docs/08_管理グループとポリシー.md
+++ b/docs-site/docs/08_管理グループとポリシー.md
@@ -37,7 +37,7 @@
 
 **📊 このプロジェクトの管理グループ階層（完全版）**
 
-```
+```text title="管理グループの完全な階層構造"
 Tenant Root Group（最上位）
 │
 └── alz（Azure Landing Zones）
@@ -97,7 +97,7 @@ Tenant Root Group（最上位）
 | **sandbox** | 実験環境 | 全員 | 緩い（自由に実験） |
 | **decommissioned** | 廃止予定 | 削除担当者 | 読み取り専用 |
 
-```
+```text title="管理グループ階層の簡易図"
 Tenant Root Group（テナントルート）
   └── alz（Azure Landing Zones）
       ├── platform（プラットフォーム）
@@ -121,19 +121,19 @@ Tenant Root Group（テナントルート）
 ### なんで階層化するの？
 
 **理由1：ガバナンス**
-```
+```text title="階層ごとのポリシー適用"
 platform配下：厳しいセキュリティポリシー
 sandbox配下：緩いポリシー（実験用）
 ```
 
 **理由2：権限管理**
-```
+```text title="階層ごとの権限分離"
 platformの管理者：platform配下だけ触れる
 landingzonesの管理者：landingzones配下だけ触れる
 ```
 
 **理由3：コスト管理**
-```
+```text title="階層ごとのコスト集計"
 platform：インフラコスト
 landingzones：アプリケーションコスト
 → 分けて集計できる
@@ -145,7 +145,7 @@ landingzones：アプリケーションコスト
 
 ### ファイル構造
 
-```
+```text title="アーキテクチャ定義ファイルの場所"
 lib/
   └── architecture_definitions/
       └── alz_custom.alz_architecture_definition.yaml  # ←これ
@@ -153,7 +153,7 @@ lib/
 
 ### 内容を見てみよう
 
-```yaml
+```yaml title="alz_custom.alz_architecture_definition.yaml の基本構造"
 name: alz_custom
 management_groups:
   - id: alz
@@ -167,7 +167,7 @@ management_groups:
 **フィールド解説**：
 
 #### id
-```yaml
+```yaml title="管理グループのID"
 id: alz
 ```
 
@@ -179,7 +179,7 @@ id: alz
 - 一意（重複不可）
 
 #### display_name
-```yaml
+```yaml title="表示名の設定"
 display_name: Azure Landing Zones
 ```
 
@@ -188,7 +188,7 @@ display_name: Azure Landing Zones
 Azureポータルでこの名前が表示される。
 
 #### archetypes
-```yaml
+```yaml title="適用するポリシーテンプレート"
 archetypes:
   - root_custom
 ```
@@ -198,7 +198,7 @@ archetypes:
 `lib/archetype_definitions/root_custom.alz_archetype_override.yaml`を参照。
 
 #### exists
-```yaml
+```yaml title="既存リソースか新規作成か"
 exists: false
 ```
 
@@ -208,7 +208,7 @@ exists: false
 - `true`：既存（参照のみ）
 
 #### parent_id
-```yaml
+```yaml title="親管理グループの指定"
 parent_id: null
 ```
 
@@ -219,7 +219,7 @@ parent_id: null
 
 ### 階層の全体像
 
-```yaml
+```yaml title="全管理グループの親子関係定義"
 # ルート
 - id: alz
   parent_id: null  # ←テナントルート直下
@@ -260,7 +260,7 @@ parent_id: null
 ```
 
 **図にするとこう**：
-```
+```text title="管理グループ階層のツリー表示"
 alz
 ├── platform
 │   ├── management
@@ -290,7 +290,7 @@ alz
 
 ### ファイル構造
 
-```
+```text title="アーキタイプ定義ファイル一覧"
 lib/
   └── archetype_definitions/
       ├── root_custom.alz_archetype_override.yaml
@@ -308,7 +308,7 @@ lib/
 
 ### root_custom.alz_archetype_override.yaml
 
-```yaml
+```yaml title="ルートアーキタイプの定義"
 base_archetype: root
 name: root_custom
 policy_assignments_to_add: []
@@ -324,7 +324,7 @@ role_definitions_to_remove: []
 **フィールド解説**：
 
 #### base_archetype
-```yaml
+```yaml title="ベースアーキタイプの継承"
 base_archetype: root
 ```
 
@@ -333,14 +333,14 @@ base_archetype: root
 ALZモジュールに組み込まれてる`root`アーキタイプを継承。
 
 #### policy_assignments_to_add
-```yaml
+```yaml title="ポリシー割り当ての追加（初期状態）"
 policy_assignments_to_add: []
 ```
 
 **何？**：追加するポリシー割り当て
 
 **例**（カスタムポリシーを追加したい場合）：
-```yaml
+```yaml title="タグ付けポリシーの追加例"
 policy_assignments_to_add:
   - name: custom-tagging-policy
     policy_definition_id: /providers/Microsoft.Management/managementGroups/alz/providers/Microsoft.Authorization/policyDefinitions/custom-tags
@@ -350,14 +350,14 @@ policy_assignments_to_add:
 ```
 
 #### policy_assignments_to_remove
-```yaml
+```yaml title="ポリシー割り当ての削除（初期状態）"
 policy_assignments_to_remove: []
 ```
 
 **何？**：削除するポリシー割り当て
 
 **例**（デフォルトのポリシーを無効化したい場合）：
-```yaml
+```yaml title="デフォルトポリシーの無効化例"
 policy_assignments_to_remove:
   - Deploy-MDFC-DefenderSQL-AMA
 ```
@@ -372,7 +372,7 @@ Chapter 3で見た設定です。
 
 Chapter 3で見たこれ：
 
-```hcl
+```hcl title="管理グループ設定の全体"
 management_group_settings = {
   architecture_name = "alz"
   location          = "{{starter_location_01}}"
@@ -397,7 +397,7 @@ management_group_settings = {
 
 ### architecture_name
 
-```hcl
+```hcl title="使用するアーキテクチャ名"
 architecture_name = "alz"
 ```
 
@@ -407,7 +407,7 @@ architecture_name = "alz"
 
 ### location
 
-```hcl
+```hcl title="メタデータ保存場所"
 location = "{{starter_location_01}}"
 ```
 
@@ -417,7 +417,7 @@ location = "{{starter_location_01}}"
 
 ### policy_default_values
 
-```hcl
+```hcl title="ポリシーのデフォルトパラメータ"
 policy_default_values = {
   log_analytics_workspace_id = "{{log_analytics_workspace_id}}"
   ...
@@ -440,7 +440,7 @@ policy_assignment "logging" {
 
 ### subscription_placement
 
-```hcl
+```hcl title="サブスクリプションの配置"
 subscription_placement = {
   management   = ["{{subscription_id_management}}"]
   connectivity = ["{{subscription_id_connectivity}}"]
@@ -451,7 +451,7 @@ subscription_placement = {
 **何？**：サブスクリプションをどの管理グループに配置するか
 
 **例**：
-```hcl
+```hcl title="複数サブスクリプションの配置例"
 subscription_placement = {
   management   = ["12345678-1234-1234-1234-123456789012"]
   connectivity = ["87654321-4321-4321-4321-210987654321"]
@@ -460,7 +460,7 @@ subscription_placement = {
 ```
 
 **結果**：
-```
+```text title="サブスクリプションの配置結果"
 management グループ
   └── サブスクリプション 12345678-...
 
@@ -478,7 +478,7 @@ corp グループ
 
 ### management_groups モジュール
 
-```hcl
+```hcl title="管理グループモジュールの呼び出し"
 module "management_groups" {
   source = "./modules/management_groups"
 
@@ -491,7 +491,7 @@ module "management_groups" {
 
 #### count
 
-```hcl
+```hcl title="有効/無効の制御"
 count = var.management_groups_enabled ? 1 : 0
 ```
 
@@ -509,7 +509,7 @@ management_groups_enabled = true  # ←作る
 
 #### management_group_settings
 
-```hcl
+```hcl title="処理済み設定の渡し"
 management_group_settings = local.management_group_settings
 ```
 
@@ -517,7 +517,7 @@ Chapter 5で見た`locals.tf`で処理された設定が渡される。
 
 ### modules/management_groups/main.tf
 
-```hcl
+```hcl title="ALZ公式モジュールの使用"
 module "management_groups" {
   source  = "Azure/avm-ptn-alz/azurerm"
   version = "0.14.1"
@@ -546,7 +546,7 @@ https://registry.terraform.io/modules/Azure/avm-ptn-alz/azurerm
 
 #### 1. Audit（監査）
 
-```
+```text title="Auditポリシーの動作"
 「これやっちゃダメだけど、やってもエラーにはしない」
 → ポリシー違反として記録
 ```
@@ -558,7 +558,7 @@ https://registry.terraform.io/modules/Azure/avm-ptn-alz/azurerm
 
 #### 2. Deny（拒否）
 
-```
+```text title="Denyポリシーの動作"
 「これやっちゃダメ。やろうとしたらエラー」
 → リソース作成を拒否
 ```
@@ -570,7 +570,7 @@ https://registry.terraform.io/modules/Azure/avm-ptn-alz/azurerm
 
 #### 3. DeployIfNotExists（自動デプロイ）
 
-```
+```text title="DeployIfNotExistsポリシーの動作"
 「これがなかったら自動で作る」
 → 不足しているリソースを自動作成します
 ```
@@ -582,7 +582,7 @@ https://registry.terraform.io/modules/Azure/avm-ptn-alz/azurerm
 
 #### 4. Modify（変更）
 
-```
+```text title="Modifyポリシーの動作"
 「タグとか設定を自動で変更」
 → リソースの属性を変更
 ```
@@ -594,7 +594,7 @@ https://registry.terraform.io/modules/Azure/avm-ptn-alz/azurerm
 
 ### ポリシーの割り当て
 
-```
+```text title="ポリシーの継承フロー"
 管理グループにポリシー割り当て
   ↓
 子管理グループに継承
@@ -607,7 +607,7 @@ https://registry.terraform.io/modules/Azure/avm-ptn-alz/azurerm
 ```
 
 **例**：
-```
+```text title="ポリシー継承の具体例"
 alz（ルート）
   └── ポリシー：「japaneast以外禁止」
       ↓
@@ -631,7 +631,7 @@ connectivity
 
 #### 1. アーキタイプファイル編集
 
-```yaml
+```yaml title="タグ必須化ポリシーの追加"
 # lib/archetype_definitions/root_custom.alz_archetype_override.yaml
 base_archetype: root
 name: root_custom
@@ -649,7 +649,7 @@ policy_assignments_to_add:
 
 #### 2. Terraform実行
 
-```bash
+```bash title="ポリシー変更の適用"
 terraform plan
 # ↓ポリシー割り当てが追加される
 
@@ -658,7 +658,7 @@ terraform apply
 
 #### 3. 結果
 
-```
+```text title="タグチェックの動作"
 リソース作成時：
 ❌ タグなし → エラー
 ❌ environment だけ → エラー（owner、cost_centerがない）
@@ -669,7 +669,7 @@ terraform apply
 
 Chapter 3で見たDefender for SQLを無効化する例。
 
-```yaml
+```yaml title="デフォルトポリシーの削除"
 # lib/archetype_definitions/root_custom.alz_archetype_override.yaml
 policy_assignments_to_remove:
   - Deploy-MDFC-DefenderSQL-AMA
@@ -686,7 +686,7 @@ policy_assignments_to_remove:
 
 ### 管理グループの確認
 
-```bash
+```bash title="管理グループの確認コマンド"
 # 管理グループ一覧
 az account management-group list --output table
 
@@ -699,7 +699,7 @@ az account management-group show --name alz --expand --recurse
 
 ### ポリシー割り当ての確認
 
-```bash
+```bash title="ポリシー割り当ての確認コマンド"
 # 管理グループのポリシー割り当て一覧
 az policy assignment list --scope /providers/Microsoft.Management/managementGroups/alz
 
@@ -709,13 +709,13 @@ az policy assignment show --name "Require-Tags" --scope /providers/Microsoft.Man
 
 ### ポリシーコンプライアンスの確認
 
-```bash
+```bash title="ポリシーコンプライアンス確認"
 # コンプライアンス状態
 az policy state list --resource /providers/Microsoft.Management/managementGroups/alz
 ```
 
 Azureポータル：
-```
+```text title="ポータルでの確認手順"
 Policy → Compliance
 ↓
 管理グループごとにコンプライアンス率が見える
@@ -734,7 +734,7 @@ Error: Management group with id "alz" already exists
 **原因**：既に同じIDの管理グループが存在
 
 **対処法**：
-```yaml
+```yaml title="既存管理グループの指定"
 # alz_custom.alz_architecture_definition.yaml
 - id: alz
   exists: true  # ←既存使う
@@ -742,7 +742,7 @@ Error: Management group with id "alz" already exists
 
 または：
 
-```bash
+```bash title="既存管理グループの削除"
 # 既存削除
 az account management-group delete --name alz
 ```
@@ -756,7 +756,7 @@ Error: Cannot move subscription to management group
 **原因**：権限不足
 
 **対処法**：
-```bash
+```bash title="権限の付与"
 # 必要な権限
 # - Management Group Contributor
 # - または Owner
@@ -777,7 +777,7 @@ Error: Policy definition not found
 **原因**：policy_definition_idが間違ってる
 
 **対処法**：
-```bash
+```bash title="ポリシー定義の検索"
 # ポリシー定義を検索
 az policy definition list --query "[?displayName=='Require a tag'].id"
 
@@ -790,7 +790,7 @@ az policy definition list --query "[?displayName=='Require a tag'].id"
 
 ### パターン1: 標準ALZ（推奨）
 
-```
+```text title="標準ALZ構造"
 alz
 ├── platform
 │   ├── management
@@ -808,7 +808,7 @@ alz
 
 ### パターン2: シンプル構成
 
-```
+```text title="シンプルな3階層構造"
 company
 ├── production
 ├── development
@@ -820,7 +820,7 @@ company
 
 ### パターン3: 環境 × 機能
 
-```
+```text title="環境と機能のマトリックス構造"
 company
 ├── prod
 │   ├── apps
@@ -838,7 +838,7 @@ company
 
 ### おすすめ：標準ALZ + カスタマイズ
 
-```
+```text title="標準ALZ拡張構造"
 alz
 ├── platform（そのまま）
 ├── landingzones


### PR DESCRIPTION
## 変更内容

- Chapter 08（08_管理グループとポリシー.md）に35個以上のコードタイトルを追加
- 管理グループとポリシーの完全解説を装飾
- 階層構造、アーキテクチャ定義、アーキタイプ、設定ファイル、ポリシー種類にコードタイトルを付与

## 装飾内容

- 管理グループ階層構造（完全版・簡易版）
- 各層の役割まとめ（表形式）
- アーキテクチャ定義（YAML構造、フィールド解説）
- アーキタイプ定義（root_custom、ポリシー追加/削除）
- tfvars設定（architecture_name、location、policy_default_values、subscription_placement）
- モジュール呼び出し（count制御、ALZ公式モジュール）
- ポリシー種類4つ（Audit、Deny、DeployIfNotExists、Modify）
- ポリシー継承フロー
- 実践例2つ（タグ必須化、既存ポリシー削除）
- デバッグ技術（Azure CLI、ポータル確認）
- よくあるエラー3つと対処法
- 設計パターン4種類（標準ALZ、シンプル、環境×機能、カスタマイズ）

## 確認事項

- [x] 文章は一言一句変更していない（マークアップのみ追加）
- [x] ビルド成功を確認
- [x] コードタイトルのみ追加（コード内容は変更なし）